### PR TITLE
flang: build with LLVM on Linux

### DIFF
--- a/Formula/flang.rb
+++ b/Formula/flang.rb
@@ -19,10 +19,11 @@ class Flang < Formula
   depends_on "cmake" => :build
   depends_on "gcc" => :test # for gfortran
   depends_on "llvm"
-
   uses_from_macos "zlib"
 
   fails_with gcc: "5"
+  fails_with gcc: "6"
+  fails_with :gcc if OS.linux?
 
   def install
     llvm_cmake_lib = Formula["llvm"].opt_lib/"cmake"


### PR DESCRIPTION
We're already installing LLVM for this, so we may as well build this
with Clang.