### PR TITLE
libwhich: add `-rpath` flag

### DIFF
--- a/Formula/libwhich.rb
+++ b/Formula/libwhich.rb
@@ -19,8 +19,8 @@ class Libwhich < Formula
   depends_on "gnu-sed" => :test
 
   def install
-    system "make"
-    bin.install "libwhich"
+    ENV.append "LDFLAGS", "-Wl,-rpath,#{rpath(target: HOMEBREW_PREFIX/"lib")}"
+    system "make", "prefix=#{prefix}", "install"
     inreplace "test-libwhich.sh", "./libwhich", "#{bin}/libwhich"
     libexec.install "test-libwhich.sh"
   end


### PR DESCRIPTION
This will allow `libwhich` to find linked Homebrew libraries without
having to specify full paths.

Also, use the `install` target, since they have one now.
